### PR TITLE
Added reset-password(sends mail to user) and new-password API's

### DIFF
--- a/client/src/NewPwd.js
+++ b/client/src/NewPwd.js
@@ -1,0 +1,56 @@
+import React, { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import M from "materialize-css";
+const NewPwd = () => {
+  const navigate = useNavigate();
+  const [password, setPasword] = useState("");
+  const { token } = useParams();
+  console.log(token);
+  const PostData = () => {
+    fetch("/new-password", {
+      method: "post",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        password,
+        token,
+      }),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        console.log(data);
+        if (data.error) {
+          M.toast({ html: data.error, classes: "#c62828 red darken-3" });
+        } else {
+          M.toast({ html: data.message, classes: "#43a047 green darken-1" });
+          navigate("/signin");
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+  return (
+    <div className="mycard">
+      <div className="card auth-card input-field">
+        <h2>scrumNcoke</h2>
+
+        <input
+          type="password"
+          placeholder="enter a new password"
+          value={password}
+          onChange={(e) => setPasword(e.target.value)}
+        />
+        <button
+          className="btn waves-effect waves-light #64b5f6 blue darken-1"
+          onClick={() => PostData()}
+        >
+          Update password
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default NewPwd;

--- a/client/src/ResetPwd.js
+++ b/client/src/ResetPwd.js
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import M from "materialize-css";
+const ResetPwd = () => {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const PostData = () => {
+    if (
+      !/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(
+        email
+      )
+    ) {
+      M.toast({ html: "invalid email", classes: "#c62828 red darken-3" });
+      return;
+    }
+    fetch("/reset-password", {
+      method: "post",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email,
+      }),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.error) {
+          M.toast({ html: data.error, classes: "#c62828 red darken-3" });
+        } else {
+          M.toast({ html: data.message, classes: "#43a047 green darken-1" });
+          navigate("/signIn");
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+  return (
+    <div className="mycard">
+      <div className="card auth-card input-field">
+        <h2>scrumNcoke</h2>
+        <input
+          type="text"
+          placeholder="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <button
+          className="btn waves-effect waves-light #64b5f6 blue darken-1"
+          onClick={() => PostData()}
+        >
+          reset password
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPwd;

--- a/discord_replica/routes/auth.js
+++ b/discord_replica/routes/auth.js
@@ -3,9 +3,20 @@ const router = express.Router();
 const mongoose = require("mongoose");
 const User = mongoose.model("User");
 const bcrypt = require("bcryptjs");
+const crypto = require("crypto");
 const jwt = require("jsonwebtoken");
-const { JWT_SECRET } = require("../keys");
+const { JWT_SECRET, SENDGRID_API } = require("../keys");
 const requireLogin = require("../middleware/requireLogin");
+const nodemailer = require("nodemailer");
+const sendgridTransport = require("nodemailer-sendgrid-transport");
+
+const transporter = nodemailer.createTransport(
+  sendgridTransport({
+    auth: {
+      api_key: SENDGRID_API,
+    },
+  })
+);
 
 router.get("/protected", requireLogin, (req, res) => {
   console.log(req);
@@ -94,6 +105,60 @@ router.post("/signin", (req, res) => {
         console.log(err);
       });
   });
+});
+
+router.post("/reset-password", (req, res) => {
+  crypto.randomBytes(32, (err, buffer) => {
+    if (err) {
+      console.log(err);
+    }
+    const token = buffer.toString("hex");
+    User.findOne({ email: req.body.email }).then((user) => {
+      if (!user) {
+        return res
+          .status(422)
+          .json({ error: "User doesn't exists with that email" });
+      }
+      user.resetToken = token;
+      user.expireToken = Date.now() + 3600000;
+      user.save().then((result) => {
+        transporter.sendMail({
+          to: "aitha.prasad@bennett.edu.in", //need to replace with user.email in prod env,
+          from: "udayprasad.aitha@slu.edu",
+          subject: "password reset",
+          html: `
+                  <p>You requested for password reset</p>
+                  <h5>Click on this <a href="http://localhost:3000/reset/${token}">link</a> to reset password</h5>
+                  `,
+        });
+        res.json({ message: "Please check your email for further steps" });
+      });
+    });
+  });
+});
+
+router.post("/new-password", (req, res) => {
+  const newPassword = req.body.password;
+  const sentToken = req.body.token;
+  User.findOne({ resetToken: sentToken, expireToken: { $gt: Date.now() } })
+    .then((user) => {
+      if (!user) {
+        return res
+          .status(422)
+          .json({ error: "Please try again, your session expired" });
+      }
+      bcrypt.hash(newPassword, 12).then((hashedpassword) => {
+        user.password = hashedpassword;
+        user.resetToken = undefined;
+        user.expireToken = undefined;
+        user.save().then((saveduser) => {
+          res.json({ message: "password updated success" });
+        });
+      });
+    })
+    .catch((err) => {
+      console.log(err);
+    });
 });
 
 module.exports = router;


### PR DESCRIPTION
1. Verification of the email whether it exists in our database.
2. Send an email to the user with the link to reset his password(using node transporter)
3. Making the link inactive after one hour (for security reasons).
4. Replacing the old password with the new password and saving it to the DB.
5. Sending the respective response to frontend. 

With the mail ID which exists in our DB
![image](https://user-images.githubusercontent.com/30821659/157091457-4b7bf5cd-1d52-49e0-b490-e14d10c95ffb.png)
With the mail ID which does not exist in our DB
![image](https://user-images.githubusercontent.com/30821659/157091679-e8db2e50-b375-4941-b4e3-bac8852d6967.png)
Receive mail with the reset link
![image](https://user-images.githubusercontent.com/30821659/157091847-87998231-1f83-40b7-b91e-769d37ffb461.png)
Triggering new-password API with the received token from the email sent
![image](https://user-images.githubusercontent.com/30821659/157091966-d321f9a1-69f5-41a5-8e04-041cd0f638f9.png)

Front end for reset password:

 
![WhatsApp Image 2022-03-07 at 7 51 54 PM](https://user-images.githubusercontent.com/98608131/157150796-416cf57f-4313-471c-922d-690b09ab5f6b.jpeg)
